### PR TITLE
Use react-native-google-sign-in

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,12 +14,12 @@ $ npm install --save react-native-firebase-auth
 ## Project Setup
 
 ```
-$ npm install --save firebase react-native-facebook-login react-native-google-signin
+$ npm install --save firebase react-native-facebook-login react-native-google-sign-in
 ```
 
-You will need fully setup both of the below social platform dependencies (react-native-google-signin and react-native-facebook-login).
+You will need fully setup both of the below social platform dependencies (react-native-google-sign-in and react-native-facebook-login).
 
-https://github.com/devfd/react-native-google-signin#project-setup-and-initialization
+https://github.com/joonhocho/react-native-google-sign-in#getting-started
 https://github.com/magus/react-native-facebook-login#setup
 
 You will need to initialise Firebase within your app in the usual way. See https://firebase.google.com/docs/web/setup
@@ -96,4 +96,4 @@ updatePassword () => {
 
 https://github.com/magus/react-native-facebook-login
 
-https://github.com/devfd/react-native-google-signin
+https://github.com/joonhocho/react-native-google-sign-in

--- a/README.md
+++ b/README.md
@@ -9,10 +9,13 @@ Using this module alongside Firebase means there is no need to write and host an
 Use our project starter repository (https://github.com/SolidStateGroup/firebase-project-starter) to help you get started setting up your own Firebase project.
 
 
-## Install
+## Installation
+
 ```
 $ npm install --save react-native-firebase-auth
 ```
+
+**Note:** If you use React Native < `v0.39` or you are already using `react-native-google-signin` then stick with `v0.0.11` (`npm install react-native-firebase-auth@0.0.11 --save`)
 
 ## Project Setup
 

--- a/auth.js
+++ b/auth.js
@@ -1,5 +1,5 @@
 import { FBLoginManager } from 'react-native-facebook-login';
-import { GoogleSignIn } from 'react-native-google-sign-in';
+import GoogleSignIn from 'react-native-google-sign-in';
 
 const Facebook = {
   login: (permissions) => {

--- a/auth.js
+++ b/auth.js
@@ -1,5 +1,5 @@
 import { FBLoginManager } from 'react-native-facebook-login';
-import { GoogleSignin } from 'react-native-google-signin';
+import { GoogleSignIn } from 'react-native-google-sign-in';
 
 const Facebook = {
   login: (permissions) => {
@@ -28,11 +28,11 @@ const Facebook = {
 
 const Google = {
   configure: (options) => {
-    GoogleSignin.configure(options);
+    GoogleSignIn.configure(options);
   },
   login: () => {
     return new Promise((resolve, reject) => {
-      GoogleSignin.signIn()
+      GoogleSignIn.signInPromise()
         .then((user) => {
           resolve(user.accessToken);
         })
@@ -44,7 +44,7 @@ const Google = {
   },
   logout: () => {
     return new Promise((resolve, reject) => {
-      GoogleSignin.signOut()
+      GoogleSignIn.signOutPromise()
         .then(() => {
           resolve(true);
         })

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-firebase-auth",
-  "version": "0.0.11",
+  "version": "1.0.0",
   "description": "Simplified Firebase authentication with social platform support",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "firebase": ">=3.0.0",
     "react-native": ">=0.30.0",
     "react-native-facebook-login": ">=1.4.0",
-    "react-native-google-signin": ">=0.8.0"
+    "react-native-google-sign-in": ">=0.0.8"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Switches use of `react-native-google-signin` to `react-native-google-sign-in` which is a newer actively maintained better alternative to the original module.

This would be a breaking change.